### PR TITLE
Add HashiCorp Vault integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ in this quetions.
 👆second step🤞
 
 you must make Telegram bot and take him token in botfather 
-'''
+'''\n### Secrets management\nThis project can load configuration from [HashiCorp Vault](https://www.vaultproject.io/). Set `VAULT_ADDR` and `VAULT_TOKEN` environment variables. If `DB_URL` is not present in the environment, the application will fetch it from `VAULT_DB_PATH` using optional `VAULT_DB_KEY` (defaults to `DB_URL`).\n

--- a/infrastructure/database/engine.py
+++ b/infrastructure/database/engine.py
@@ -1,10 +1,23 @@
 from sqlalchemy import create_engine
 import os
 from dotenv import load_dotenv
+from infrastructure.vault_client import VaultClient
 
 load_dotenv()
 
-DATABASE_URL = os.getenv('DB_URL')
+DATABASE_URL = os.getenv("DB_URL")
 
-DATABASE_URL = DATABASE_URL
+if DATABASE_URL is None:
+    secret_path = os.getenv("VAULT_DB_PATH")
+    secret_key = os.getenv("VAULT_DB_KEY", "DB_URL")
+    if secret_path:
+        try:
+            client = VaultClient()
+            DATABASE_URL = client.read_secret(secret_path, secret_key)
+        except Exception:
+            DATABASE_URL = None
+
+if not DATABASE_URL:
+    raise RuntimeError("Database URL not configured")
+
 engine = create_engine(DATABASE_URL, echo=False, future=True)

--- a/infrastructure/vault_client.py
+++ b/infrastructure/vault_client.py
@@ -1,0 +1,18 @@
+import os
+import hvac
+
+
+class VaultClient:
+    """Simple wrapper around hvac Client for retrieving secrets."""
+
+    def __init__(self):
+        url = os.getenv("VAULT_ADDR")
+        token = os.getenv("VAULT_TOKEN")
+        if not url or not token:
+            raise EnvironmentError("Vault configuration is missing")
+        self.client = hvac.Client(url=url, token=token)
+
+    def read_secret(self, path: str, key: str) -> str | None:
+        """Read a specific key from a Vault KV v2 secret."""
+        secret = self.client.secrets.kv.v2.read_secret_version(path=path)
+        return secret["data"]["data"].get(key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+hvac>=1.3.0
+python-dotenv>=1.0.0
+SQLAlchemy>=2.0.0


### PR DESCRIPTION
## Summary
- add VaultClient for working with HashiCorp Vault
- load DB credentials from Vault when available
- document Vault integration
- specify new dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684968eea8a0832a9cd10f4e04ca9ddc